### PR TITLE
Remove `jupyter` key from frontmatter

### DIFF
--- a/book/00_Introduction_Setup/02_Introduction_to_Open_Science.md
+++ b/book/00_Introduction_Setup/02_Introduction_to_Open_Science.md
@@ -1,17 +1,3 @@
----
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
----
-
 # Introduction to Open Science
 
 <!-- #region jupyter={"source_hidden": false} -->

--- a/book/01_Geospatial_Background/02_Working_with_Raster_Data.md
+++ b/book/01_Geospatial_Background/02_Working_with_Raster_Data.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Working with Raster Data

--- a/book/01_Geospatial_Background/03_Working_with_Vector_Data.md
+++ b/book/01_Geospatial_Background/03_Working_with_Vector_Data.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Working with Vector Data

--- a/book/02_Software_Tools_Techniques/01_Loading_Raster_Data_from_GeoTIFF_Files.md
+++ b/book/02_Software_Tools_Techniques/01_Loading_Raster_Data_from_GeoTIFF_Files.md
@@ -6,9 +6,9 @@ text_representation:
     format_version: '1.3'
     jupytext_version: 1.16.2
 kernelspec:
-display_name: Python 3 (ipykernel)
-language: python
-name: python3
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
 ---
 
 # Loading Raster Data from GeoTIFF Files

--- a/book/02_Software_Tools_Techniques/01_Loading_Raster_Data_from_GeoTIFF_Files.md
+++ b/book/02_Software_Tools_Techniques/01_Loading_Raster_Data_from_GeoTIFF_Files.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+display_name: Python 3 (ipykernel)
+language: python
+name: python3
 ---
 
 # Loading Raster Data from GeoTIFF Files

--- a/book/02_Software_Tools_Techniques/02_Array_Manipulation_with_Xarray.md
+++ b/book/02_Software_Tools_Techniques/02_Array_Manipulation_with_Xarray.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Array Manipulation with [Xarray](https://docs.xarray.dev/en/stable/index.html)

--- a/book/02_Software_Tools_Techniques/03_Data_Visualization_with_GeoViews_HvPlot.md
+++ b/book/02_Software_Tools_Techniques/03_Data_Visualization_with_GeoViews_HvPlot.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Data Visualization with GeoViews & HvPlot

--- a/book/02_Software_Tools_Techniques/04_Constructing_Advanced_Visualizations.md
+++ b/book/02_Software_Tools_Techniques/04_Constructing_Advanced_Visualizations.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Constructing Advanced Visualizations

--- a/book/03_Using_NASA_EarthData/01_Using_OPERA_DIST_Products.md
+++ b/book/03_Using_NASA_EarthData/01_Using_OPERA_DIST_Products.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.4
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 ---
 
 # Using OPERA DIST Products

--- a/book/03_Using_NASA_EarthData/02_Using_OPERA_DSWx_Products.md
+++ b/book/03_Using_NASA_EarthData/02_Using_OPERA_DSWx_Products.md
@@ -1,12 +1,11 @@
 ---
-jupyter:
-  jupytext:
+jupytext:
     text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
+        extension: .md
+        format_name: markdown
+        format_version: '1.3'
+        jupytext_version: 1.16.2
+kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
     name: python3

--- a/book/03_Using_NASA_EarthData/03_Using_PySTAC.md
+++ b/book/03_Using_NASA_EarthData/03_Using_PySTAC.md
@@ -1,12 +1,11 @@
 ---
-jupyter:
-  jupytext:
+jupytext:
     text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
+        extension: .md
+        format_name: markdown
+        format_version: '1.3'
+        jupytext_version: 1.16.2
+kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
     name: python3

--- a/book/04_Case_Studies/00_Template.md
+++ b/book/04_Case_Studies/00_Template.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+display_name: Python 3 (ipykernel)
+language: python
+name: python3
 ---
 
 # Template for using EarthData cloud

--- a/book/04_Case_Studies/00_Template.md
+++ b/book/04_Case_Studies/00_Template.md
@@ -1,14 +1,14 @@
 ---
 jupytext:
-text_representation:
-    extension: .md
-    format_name: markdown
-    format_version: '1.3'
-    jupytext_version: 1.16.2
+    text_representation:
+        extension: .md
+        format_name: markdown
+        format_version: '1.3'
+        jupytext_version: 1.16.2
 kernelspec:
-display_name: Python 3 (ipykernel)
-language: python
-name: python3
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
 ---
 
 # Template for using EarthData cloud

--- a/book/04_Case_Studies/01_Greece_Wildfires.md
+++ b/book/04_Case_Studies/01_Greece_Wildfires.md
@@ -1,14 +1,14 @@
 ---
 jupytext:
-text_representation:
-    extension: .md
-    format_name: markdown
-    format_version: '1.3'
-    jupytext_version: 1.16.2
+    text_representation:
+        extension: .md
+        format_name: markdown
+        format_version: '1.3'
+        jupytext_version: 1.16.2
 kernelspec:
-display_name: Python 3 (ipykernel)
-language: python
-name: python3
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
 ---
 
 # Greece Wildfires

--- a/book/04_Case_Studies/01_Greece_Wildfires.md
+++ b/book/04_Case_Studies/01_Greece_Wildfires.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.2
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.2
+kernelspec:
+display_name: Python 3 (ipykernel)
+language: python
+name: python3
 ---
 
 # Greece Wildfires

--- a/book/04_Case_Studies/02_Lake_Mead_Mosaicking.md
+++ b/book/04_Case_Studies/02_Lake_Mead_Mosaicking.md
@@ -1,14 +1,14 @@
 ---
 jupytext:
-text_representation:
-    extension: .md
-    format_name: markdown
-    format_version: '1.3'
-    jupytext_version: 1.16.4
+    text_representation:
+        extension: .md
+        format_name: markdown
+        format_version: '1.3'
+        jupytext_version: 1.16.4
 kernelspec:
-display_name: Python 3 (ipykernel)
-language: python
-name: python3
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
 ---
 
 # Generating a Mosaicked Image of Lake Mead

--- a/book/04_Case_Studies/02_Lake_Mead_Mosaicking.md
+++ b/book/04_Case_Studies/02_Lake_Mead_Mosaicking.md
@@ -1,15 +1,14 @@
 ---
-jupyter:
-  jupytext:
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.16.4
-  kernelspec:
-    display_name: Python 3 (ipykernel)
-    language: python
-    name: python3
+jupytext:
+text_representation:
+    extension: .md
+    format_name: markdown
+    format_version: '1.3'
+    jupytext_version: 1.16.4
+kernelspec:
+display_name: Python 3 (ipykernel)
+language: python
+name: python3
 ---
 
 # Generating a Mosaicked Image of Lake Mead


### PR DESCRIPTION
Remove the top-level jupyter: key from the [jupytext markdown frontmatter](https://jupytext.readthedocs.io/en/latest/formats-markdown.html#jupytext-markdown) so that code-cell directive is interactive in JLab interface (behaves as a Markdown cell otherwise)

>[!note]
>Merge EOD Friday in case the bug is not fixed by then.