### PR TITLE
Revert "Create netrc file for earthdata credentials"

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 set -eux
 
-# Override to open jupytext md files as notebooks
 mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
 cp binder/overrides.json ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
-
-# .netrc for earthdata credentials
-touch ${HOME}/.netrc | chmod og-rw ${HOME}/.netrc | echo machine urs.earthdata.nasa.gov >> ${HOME}/.netrc
-echo login ${EARTHDATA_USERNAME} >> ~/.netrc | echo password ${EARTHDATA_PASSWORD} >> ${HOME}/.netrc


### PR DESCRIPTION
Reverts 2i2c-org/demo-Sciencecore-climaterisk#2.

(earthdata env vars are only available inside the hub image container and not at binder build time)